### PR TITLE
Update thousand_island to 1.0

### DIFF
--- a/lib/orbit/capsule.ex
+++ b/lib/orbit/capsule.ex
@@ -74,19 +74,22 @@ defmodule Orbit.Capsule do
   end
 
   defp cert_opts!(opts) do
-    cond do
-      certfile = opts[:certfile] ->
-        [certfile: certfile]
+    opts =
+      cond do
+        certfile = opts[:certfile] ->
+          [certfile: certfile]
 
-      cert = opts[:cert] ->
-        [cert: cert]
+        cert = opts[:cert] ->
+          [cert: cert]
 
-      cert_pem = opts[:cert_pem] ->
-        [cert: decode_pem!(:Certificate, cert_pem)]
+        cert_pem = opts[:cert_pem] ->
+          [cert: decode_pem!(:Certificate, cert_pem)]
 
-      :else ->
-        raise "the certificate was not provided; specify one of: :cert, :cert_pem, :certfile"
-    end
+        :else ->
+          raise "the certificate was not provided; specify one of: :cert, :cert_pem, :certfile"
+      end
+
+    [[cacerts: :public_key.cacerts_get()] | opts]
   end
 
   defp key_opts!(opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Orbit.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:thousand_island, "~> 0.6.7"},
+      {:thousand_island, "~> 1.0"},
       {:mime, "~> 2.0"},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:x509, "~> 0.8.7"}

--- a/mix.lock
+++ b/mix.lock
@@ -7,6 +7,6 @@
   "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "thousand_island": {:hex, :thousand_island, "0.6.7", "3a91a7e362ca407036c6691e8a4f6e01ac8e901db3598875863a149279ac8571", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "541a5cb26b88adf8d8180b6b96a90f09566b4aad7a6b3608dcac969648cf6765"},
+  "thousand_island": {:hex, :thousand_island, "1.0.0", "63fc8807d8607c9d74fa670996897c8c8a1f2022c8c68d024182e45249acd756", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "996320c72ba8f34d7be9b02900622e44341649f24359e0f67643e4dda8f23995"},
   "x509": {:hex, :x509, "0.8.7", "576130ad83731613fdb5787917f2fadbe308b6f5a48ed6e865a4b6be3fa802d0", [:mix], [], "hexpm", "3604125d6a0171da6e8a935810b58c999fccab0e3d20b2ed28d97fa2d9e2f6b4"},
 }


### PR DESCRIPTION
This updates thousand_island to 1.0 AND makes orbit compatible with erlang 26